### PR TITLE
Decorate

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ module.exports = function base(app) {
    */
 
   function decorate(val) {
-    if (isObject(val) && !val.use && !val.run) {
+    if (isObject(val) && (!val.use || !val.run)) {
       base(val);
     }
   }

--- a/test.js
+++ b/test.js
@@ -2,6 +2,7 @@
 
 require('mocha');
 var assert = require('assert');
+var define = require('define-property');
 var use = require('./');
 
 describe('use', function() {
@@ -15,16 +16,25 @@ describe('use', function() {
     assert.equal(typeof app.use, 'function');
   });
 
-  it('should decorate "run" onto the given object', function() {
-    var app = {};
-    use(app);
-    assert.equal(typeof app.run, 'function');
-  });
-
   it('should decorate "fns" onto the given object', function() {
     var app = {};
     use(app);
     assert(Array.isArray(app.fns));
+  });
+
+  it('should not re-add decorate methods onto the given object', function() {
+    var app = {};
+    use(app);
+    assert(Array.isArray(app.fns));
+    assert(app.fns.length === 0);
+    app.use(function() {
+      return function(ctx) {
+        ctx.foo = 'bar';
+      };
+    });
+    assert(app.fns.length === 1);
+    use(app);
+    assert(app.fns.length === 1);
   });
 
   it('should immediately invoke a plugin function', function() {
@@ -51,6 +61,19 @@ describe('use', function() {
     });
     assert(app.fns.length === 3);
   });
+});
+
+describe('run', function() {
+  it('should decorate "run" onto the given object', function() {
+    var app = {};
+    use(app);
+    assert.equal(typeof app.run, 'function');
+  });
+
+  it('should return app', function() {
+    var app = {};
+    assert.equal(typeof use(app), 'object');
+  });
 
   it('should run all plugins on "fns"', function() {
     var app = {};
@@ -74,17 +97,114 @@ describe('use', function() {
     app.run(foo);
     assert.deepEqual(foo,  { a: 'b', c: 'd', e: 'f' });
   });
-});
 
-describe('run', function() {
-  it('should decorate "run" onto the given object', function() {
+  it('should run all plugins on "fns" and decorate ctx', function() {
     var app = {};
     use(app);
-    assert.equal(typeof app.run, 'function');
+    app.use(function(ctx) {
+      return function(foo) {
+        foo.a = 'b';
+      }
+    });
+    app.use(function(ctx) {
+      return function(foo) {
+        foo.c = 'd';
+      }
+    });
+    app.use(function(ctx) {
+      return function(foo) {
+        foo.e = 'f';
+      }
+    });
+    var foo = {};
+    app.run(foo);
+    assert.deepEqual(foo,  { a: 'b', c: 'd', e: 'f' });
+    assert.equal(typeof foo.use, 'function');
+    assert.equal(typeof foo.run, 'function');
+    assert(Array.isArray(foo.fns));
   });
 
-  it('should return app', function() {
+  it('should run all plugins on "fns" and decorate ctx when .use is defined but .run is not', function() {
     var app = {};
-    assert.equal(typeof use(app), 'object');
+    use(app);
+    app.use(function(ctx) {
+      return function(foo) {
+        foo.a = 'b';
+      }
+    });
+    app.use(function(ctx) {
+      return function(foo) {
+        foo.c = 'd';
+      }
+    });
+    app.use(function(ctx) {
+      return function(foo) {
+        foo.e = 'f';
+      }
+    });
+    var foo = {};
+    define(foo, 'use', function() {});
+    app.run(foo);
+    assert.deepEqual(foo,  { a: 'b', c: 'd', e: 'f' });
+    assert.equal(typeof foo.use, 'function');
+    assert.equal(typeof foo.run, 'function');
+    assert(Array.isArray(foo.fns));
+  });
+
+  it('should run all plugins on "fns" and decorate ctx when .run is defined but .use is not', function() {
+    var app = {};
+    use(app);
+    app.use(function(ctx) {
+      return function(foo) {
+        foo.a = 'b';
+      }
+    });
+    app.use(function(ctx) {
+      return function(foo) {
+        foo.c = 'd';
+      }
+    });
+    app.use(function(ctx) {
+      return function(foo) {
+        foo.e = 'f';
+      }
+    });
+    var foo = {};
+    define(foo, 'run', function() {});
+    app.run(foo);
+    assert.deepEqual(foo,  { a: 'b', c: 'd', e: 'f' });
+    assert.equal(typeof foo.use, 'function');
+    assert.equal(typeof foo.run, 'function');
+    assert(Array.isArray(foo.fns));
+  });
+
+  it('should run all plugins on "fns" and not decorate ctx when .use and .run are already defined', function() {
+    var app = {};
+    use(app);
+    app.use(function(ctx) {
+      return function(foo) {
+        foo.a = 'b';
+      }
+    });
+    app.use(function(ctx) {
+      return function(foo) {
+        foo.c = 'd';
+      }
+    });
+    app.use(function(ctx) {
+      return function(foo) {
+        foo.e = 'f';
+      }
+    });
+    var foo = {};
+    define(foo, 'use', function(fn) {
+      return fn.call(this, this);
+    });
+    define(foo, 'run', function() {});
+    app.run(foo);
+    assert.deepEqual(foo,  { a: 'b', c: 'd', e: 'f' });
+    assert.equal(typeof foo.use, 'function');
+    assert.equal(typeof foo.run, 'function');
+    assert.equal(typeof foo.fns, 'undefined');
   });
 });


### PR DESCRIPTION
Decorating child objects when `.use` or `.run` are not added. 100% code coverage.
