### PR TITLE
part of the things in #4

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,8 +82,16 @@ module.exports = function base(app, opts) {
    * `fns` array to be called by the `run` method.
    */
 
-  function use(fn) {
+  function use(fn, options) {
+    if (typeof fn !== 'function') {
+      throw new TypeError('.use expect `fn` be function');
+    }
     var self = this || app;
+
+    if (typeof opts.fn === 'function') {
+      opts.fn.call(self, self, options);
+    }
+
     var plugin = fn.call(self, self);
     if (typeof plugin === 'function') {
       var fns = self[opts.prop];

--- a/index.js
+++ b/index.js
@@ -14,12 +14,12 @@ module.exports = function base(app, opts) {
     throw new TypeError('use: expect `app` be an object or function');
   }
 
-  opts = utils.isObject(opts) ? opts : {}
-  opts.prop = typeof opts.prop === 'string' ? opts.prop : 'fns'
-  opts.prop = opts.prop.length > 0 ? opts.prop : 'fns'
+  opts = utils.isObject(opts) ? opts : {};
+  opts.prop = typeof opts.prop === 'string' ? opts.prop : 'fns';
+  opts.prop = opts.prop.length > 0 ? opts.prop : 'fns';
 
   if (!utils.isArray(app[opts.prop])) {
-    utils.define(app, opts.prop, [])
+    utils.define(app, opts.prop, []);
   }
 
   /**
@@ -69,8 +69,8 @@ module.exports = function base(app, opts) {
    */
 
   utils.define(app, 'run', function (val) {
-    var self = this || app
-    var fns = self[opts.prop]
+    var self = this || app;
+    var fns = self[opts.prop];
     decorate(val);
     var len = fns.length, i = -1;
     while (++i < len) val.use(fns[i]);
@@ -83,10 +83,10 @@ module.exports = function base(app, opts) {
    */
 
   function use(fn) {
-    var self = this || app
+    var self = this || app;
     var plugin = fn.call(self, self);
     if (typeof plugin === 'function') {
-      var fns = self[opts.prop]
+      var fns = self[opts.prop];
       fns.push(plugin);
     }
     return self;

--- a/index.js
+++ b/index.js
@@ -7,12 +7,11 @@
 
 'use strict';
 
-var define = require('define-property');
-var isObject = require('isobject');
+var utils = require('./utils')
 
 module.exports = function base(app) {
   if (!app.fns) {
-    define(app, 'fns', []);
+    utils.define(app, 'fns', []);
   }
 
   /**
@@ -45,7 +44,7 @@ module.exports = function base(app) {
    * @api public
    */
 
-  define(app, 'use', use);
+  utils.define(app, 'use', use);
 
   /**
    * Run all plugins on `fns`. Any plugin that returns a function
@@ -61,7 +60,7 @@ module.exports = function base(app) {
    * @api public
    */
 
-  define(app, 'run', function (val) {
+  utils.define(app, 'run', function (val) {
     decorate(val);
     var len = this.fns.length, i = -1;
     while (++i < len) val.use(this.fns[i]);
@@ -86,7 +85,7 @@ module.exports = function base(app) {
    */
 
   function decorate(val) {
-    if (isObject(val) && (!val.use || !val.run)) {
+    if (utils.isObject(val) && (!val.use || !val.run)) {
       base(val);
     }
   }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "devDependencies": {
     "base-plugins": "^0.4.1",
+    "extend-shallow": "^2.0.1",
     "gulp": "^3.9.0",
     "gulp-eslint": "^1.1.0",
     "gulp-istanbul": "^0.10.2",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   },
   "license": "MIT",
   "files": [
-    "index.js"
+    "index.js",
+    "utils.js"
   ],
   "main": "index.js",
   "engines": {
@@ -21,7 +22,9 @@
   },
   "dependencies": {
     "define-property": "^0.2.5",
-    "isobject": "^2.1.0"
+    "isarray": "^1.0.0",
+    "isobject": "^2.1.0",
+    "lazy-cache": "^2.0.1"
   },
   "devDependencies": {
     "base-plugins": "^0.4.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "define-property": "^0.2.5",
-    "isobject": "^2.0.0"
+    "isobject": "^2.1.0"
   },
   "devDependencies": {
     "base-plugins": "^0.4.1",

--- a/test.js
+++ b/test.js
@@ -10,6 +10,22 @@ describe('use', function() {
     assert.equal(typeof use, 'function');
   });
 
+  it('should throw TypeError `app` not a function or object', function() {
+    function fixture () {
+      use(123);
+    }
+    assert.throws(fixture, TypeError);
+    assert.throws(fixture, /expect `app` be an object or function/);
+  });
+
+  it('should throw TypeError if not a function passed to `.use` method', function() {
+    function fixture () {
+      use({}).use(123);
+    }
+    assert.throws(fixture, TypeError);
+    assert.throws(fixture, /expect `fn` be function/);
+  });
+
   it('should decorate "use" onto the given object', function() {
     var app = {};
     use(app);
@@ -35,6 +51,15 @@ describe('use', function() {
     assert(app.fns.length === 1);
     use(app);
     assert(app.fns.length === 1);
+  });
+
+  it('should allow passing custom property to be used for plugins stack', function() {
+    var app = {};
+    use(app, { prop: 'plugins' });
+    assert.strictEqual(Array.isArray(app.fns), false);
+    assert.strictEqual(Array.isArray(app.plugins), true);
+    assert(app.plugins.length === 0);
+
   });
 
   it('should immediately invoke a plugin function', function() {

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,41 @@
+'use strict'
+
+/**
+ * Module dependencies
+ */
+
+var utils = require('lazy-cache')(require);
+
+/**
+ * Temporarily re-assign `require` to trick browserify and
+ * webpack into reconizing lazy dependencies.
+ *
+ * This tiny bit of ugliness has the huge dual advantage of
+ * only loading modules that are actually called at some
+ * point in the lifecycle of the application, whilst also
+ * allowing browserify and webpack to find modules that
+ * are depended on but never actually called.
+ */
+
+var fn = require;
+require = utils; // eslint-disable-line no-undef, no-native-reassign
+
+/**
+ * Lazily required module dependencies
+ */
+
+require('define-property', 'define');
+require('isarray', 'isArray');
+require('isobject', 'isObject');
+
+/**
+ * Restore `require`
+ */
+
+require = fn; // eslint-disable-line no-undef, no-native-reassign
+
+/**
+ * Expose `utils` modules
+ */
+
+module.exports = utils;


### PR DESCRIPTION
as considered in #4 
- allow passing options to each plugin
- allow to control (merge/extend, etc with app options) these options with `opts.fn` - better name?
- allow customizing the plugins stack property through `opts.prop`, maybe `opts.plugins` looks better?

Hope that's all of the 3 bullets, hah. And sorry if I missed some semicolon somewhere, I tried :)

About the `opts.fn`... it good to me, and make sense to remain the same, because really it can do much things. Because `.use` not limits the second argument to be only object or something. It is just directly passed to this function with the instance, so you can do anything you want. It is a bit hack, you can use it for some things "on per plugin basis".

It's always fun to port `assertit/mukla` tests to mocha, haha. Absolute compatibility and `assert` is pretty enough. Btw try http://npm.im/mukla 0.4 :)
