### PR TITLE
resolves #2 and #4 (bullets 4 and 5 of #4)

### DIFF
--- a/test.js
+++ b/test.js
@@ -151,19 +151,47 @@ describe('use', function() {
     var app = {};
     use(app);
     app.use(function(ctx) {
-      return function() {}
+      return function() {};
     });
     app.use(function(ctx) {
-      return function() {}
+      return function() {};
     });
     app.use(function(ctx) {
-      return function() {}
+      return function() {};
     });
     assert(app.fns.length === 3);
   });
+
+  it('should not call functions from `fns` immediately, only when `.run` is called', function() {
+    var app = {};
+    var count = 0;
+    use(app);
+    app.use(function(ctx) {
+      count++;
+      return function() {
+        count++;
+      };
+    });
+    app.use(function(ctx) {
+      count++;
+      return function() {
+        count++;
+      };
+    });
+    app.use(function(ctx) {
+      count++
+      return function() {
+        count++;
+      };
+    });
+    assert.strictEqual(app.fns.length, 3);
+    assert.strictEqual(count, 3);
+    app.run(123);
+    assert.strictEqual(count, 6);
+  });
 });
 
-describe('run', function() {
+describe('.run', function() {
   it('should decorate "run" onto the given object', function() {
     var app = {};
     use(app);

--- a/test.js
+++ b/test.js
@@ -189,6 +189,31 @@ describe('use', function() {
     app.run(123);
     assert.strictEqual(count, 6);
   });
+
+  it.skip('should work with infinite nesting', function() {
+    var app = {};
+    var count = 0;
+    use(app);
+
+    app.use(function (app) {
+      count++;
+      return function fn (abc) {
+        count++;
+        return function alpha (abc) {
+          count++;
+          return function beta (abc) {
+            count++;
+            return function plugin (abc) {
+              count++;
+            };
+          };
+        };
+      };
+    });
+    var foo = {};
+    app.run(foo);
+    assert.strictEqual(count, 5);
+  });
 });
 
 describe('.run', function() {

--- a/utils.js
+++ b/utils.js
@@ -13,8 +13,14 @@ require('isarray', 'isArray');
 require('isobject', 'isObject');
 require = fn; // eslint-disable-line
 
-utils.isString = function(val) {
+utils.isString = function isString(val) {
   return val && typeof val === 'string';
+};
+
+utils.arrayify = function arrayify(val) {
+  if (!val) return [];
+  if (!utils.isArray(val)) return [val];
+  return val;
 };
 
 /**


### PR DESCRIPTION
ref #2 and #4, and also switch `assert.equal` to `assert.strictEqual` (sorry, habit)

So, the whole thing around is control.
1) Control arguments of the "top-level" plugins, these that firstly are passed directly to `.use`
2) Control arguments of the "smart" (?) plugins, these that `.run` runs

Examples

``` js
var app = {}
use(app, {
  params: ['foo', 123]
})
app.use(function instantPlugin(str, num) {
  console.log(foo, bar) //=> foo, 123

  return function pluginTwo(aa, bb) {
    console.log(aa, bb) //=> 111, 222
  }
})
app.run(111, 222)
```
