### PR TITLE
Drop `isArray`.

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ module.exports = function base(app, opts) {
   }
 
   var prop = utils.isString(opts.prop) ? opts.prop : 'fns';
-  if (!utils.isArray(app[prop])) {
+  if (!Array.isArray(app[prop])) {
     utils.define(app, prop, []);
   }
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   },
   "dependencies": {
     "define-property": "^0.2.5",
-    "isarray": "^2.0.1",
     "isobject": "^3.0.0",
     "lazy-cache": "^2.0.2"
   },

--- a/utils.js
+++ b/utils.js
@@ -9,7 +9,6 @@ require = utils; // eslint-disable-line
  */
 
 require('define-property', 'define');
-require('isarray', 'isArray');
 require('isobject', 'isObject');
 require = fn; // eslint-disable-line
 


### PR DESCRIPTION
To go with #9, which would require native `Array.isArray` anyrray.